### PR TITLE
Ajusting conv_same function.

### DIFF
--- a/Ch10.jl
+++ b/Ch10.jl
@@ -8,6 +8,7 @@ function fft_len(x::AbstractVector, len::Int)
 end
 
 function conv_same(x::AbstractVector, y::AbstractVector)
+    # RoundUp is used to handle scenarios where length(y) is odd
     s = div(length(y), 2, RoundUp)
     e = length(x) + s - 1
     return conv(x, y)[s:e]


### PR DESCRIPTION
In the current definition, the return of the `conv_same(x, y)` function is not correct for: `isodd(length(y)) == true`